### PR TITLE
Exception handling in on_message callback

### DIFF
--- a/mqtt_wrapper/bridge.py
+++ b/mqtt_wrapper/bridge.py
@@ -4,7 +4,7 @@ import time
 
 class bridge:
 
-    def __init__(self, mqtt_topic, client_id = "bridge",user_id = "",password = "", host = "localhost", port = "1883", keepalive = 60):
+    def __init__(self, mqtt_topic, client_id = "bridge", user_id = "",password = "", host = "127.0.0.1", port = 1883, keepalive = 60):
         self.mqtt_topic = mqtt_topic
         self.client_id = client_id
         self.user_id = user_id
@@ -33,7 +33,7 @@ class bridge:
             try:
                 self.rc = self.client.connect(self.host, self.port, self.keepalive)
             except:
-                print "connection failed"
+                print("connection failed")
             time.sleep(2)
             self.timeout = self.timeout + 2
 
@@ -51,8 +51,8 @@ class bridge:
     def on_disconnect(self, client, userdata, rc):
         if rc != 0:
             if not self.disconnect_flag:
-                print "Unexpected disconnection."
-                print "Trying reconnection"
+                print("Unexpected disconnection.")
+                print("Trying reconnection")
                 self.rc = rc
                 self.connect()
 
@@ -60,31 +60,30 @@ class bridge:
         self.msg_process(msg)
 
     def unsubscribe(self):
-        print " unsubscribing"
+        print(" unsubscribing")
         self.client.unsubscribe(self.mqtt_topic)
 
     def disconnect(self):
-        print " disconnecting"
+        print(" disconnecting")
         self.disconnect_flag = True
         self.client.disconnect()
 
     def on_unsubscribe(self, client, userdata, mid):
         if (self.mqtt_topic == '#'):
-            print "Unsubscribed to all the topics" 
+            print("Unsubscribed to all the topics" )
         else:
-            print "Unsubscribed to " + self.mqtt_topic
+            print("Unsubscribed to '%s'" % self.mqtt_topic)
 
     def on_subscribe(self, client, userdata, mid, granted_qos):
         if (self.mqtt_topic == '#'):
-            print "Subscribed to all the topics" 
+            print("Subscribed to all the topics" )
         else:
-            print "Subscribed to " + self.mqtt_topic
-        
+            print("Subscribed to '%s'" % self.mqtt_topic)
 
     def hook(self):
         self.unsubscribe()
         self.disconnect()
-        print " shutting down"
+        print(" shutting down")
 
     def get_timeout(self):
         return self.timeout

--- a/mqtt_wrapper/bridge.py
+++ b/mqtt_wrapper/bridge.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import paho.mqtt.client as mqtt
 import time
+import traceback
 
 class bridge:
 
@@ -32,7 +33,7 @@ class bridge:
         while self.rc != 0:
             try:
                 self.rc = self.client.connect(self.host, self.port, self.keepalive)
-            except:
+            except Exception as e:
                 print("connection failed")
             time.sleep(2)
             self.timeout = self.timeout + 2
@@ -57,7 +58,10 @@ class bridge:
                 self.connect()
 
     def on_message(self, client, userdata, msg):
-        self.msg_process(msg)
+        try:
+            self.msg_process(msg)
+        except Exception as e:
+            print(traceback.format_exc())
 
     def unsubscribe(self):
         print(" unsubscribing")


### PR DESCRIPTION
One thing that bugs me about the Paho library is that it consumes _all_ exceptions silently, even syntax errors in the message handler. I am thinking I am not the only one.